### PR TITLE
Fix: return reference to list in `GetFuncListSVM`, insert `AI_OUTPUT`…

### DIFF
--- a/zParserExtender/OU.cpp
+++ b/zParserExtender/OU.cpp
@@ -151,14 +151,6 @@ namespace GOTHIC_ENGINE {
     THISCALL( Ivk_zCParser_DeclareAssign )(symName);
   }
 
-  
-  HOOK Hook_zCParser_IsInAdditionalInfo PATCH( &zCParser::IsInAdditionalInfo, &zCParser::IsInAdditionalInfo_Union );
-
-  int zCParser::IsInAdditionalInfo_Union( const zSTRING& symName ) {
-    return symName == "AI_Output";
-  }
-
-
   void zDeleteOU();
 
   HOOK Hook_zInitOptions PATCH( &zInitOptions, &zDeleteOU );

--- a/zParserExtender/OU.cpp
+++ b/zParserExtender/OU.cpp
@@ -14,13 +14,16 @@ namespace GOTHIC_ENGINE {
 
   HOOK Ivk_oCGame_LoadParserFile PATCH( &oCGame::LoadParserFile, &oCGame::LoadParserFile_Union );
 
-  zCList<zSTRING> GetFuncListSVM() {
-    static zCList<zSTRING>* funclist = new zCList<zSTRING>();
-    return *funclist;
+  zCList<zSTRING>& GetFuncListSVM() {
+    static zCList<zSTRING> funclist = [] {
+      zCList<zSTRING> list;
+      list.Insert(new zSTRING("AI_OUTPUT"));
+      return list;
+    }();
+    return funclist;
   }
 
   int oCGame::LoadParserFile_Union( zSTRING const& parserfile ) {
-    GetFuncListSVM().Insert(new zSTRING("AI_OUTPUT"));
     parser->SetInfoFile( &GetFuncListSVM(), "OuInfo.inf");
     int ok = THISCALL( Ivk_oCGame_LoadParserFile )(parserfile);
     if( zParserExtender.NeedToEarlyParsing() )

--- a/zParserExtender/ZenGin/Gothic_UserAPI/zCParser.inl
+++ b/zParserExtender/ZenGin/Gothic_UserAPI/zCParser.inl
@@ -23,7 +23,6 @@ void CallGameLoop_Union();
 void ReadWord_Union( zSTRING& );
 void ReadWordBase( zSTRING& );
 int LoadGlobalVars_Union( zCArchiver& );
-int IsInAdditionalInfo_Union( zSTRING const& );
 void RemoveAdditionalInfo_Union( zSTRING& );
 void Reset_Union();
 void ResetAdditionalInfo();


### PR DESCRIPTION
Fixed use after free of list passed to SetInfoFile. The engine stores the list pointer and uses it later. 
Previously, the list was a temporary object that was destroyed after being invoked.
Now there will be no need to hook Parser::IsInAdditionalInfo and override symbol name check.
Additionally, I moved the `AI OUTPUT` insert to construction of list to prevent leaks.