### PR TITLE
Fix parser pointers issues

### DIFF
--- a/zParserExtender/ZenGin/Gothic_UserAPI/zCPar_SymbolTable.inl
+++ b/zParserExtender/ZenGin/Gothic_UserAPI/zCPar_SymbolTable.inl
@@ -14,7 +14,7 @@ int __fastcall Search_Union( const zSTRING& name, int low, int high );
 void CheckNextSymbol( zCPar_Symbol* sym );
 void RemoveSymbolSorted( zCPar_Symbol* sym );
 void RestoreSymbolSorted( zCPar_Symbol* sym );
-uint RenameSymbol( zCPar_Symbol* sym, const zSTRING& newName, zCPar_Symbol* newSym );
+uint RenameSymbol( zCParser* scriptParser, zCPar_Symbol* sym, const zSTRING& newName, zCPar_Symbol* newSym );
 bool ReplaceSymbol( zCPar_Symbol* sym, zCPar_Symbol* newSym );
 static int Compare_Union( void const*, void const* );
 zCPar_Symbol* zCPar_SymbolTable::GetSymbol_Union( const zSTRING& s );

--- a/zParserExtender/zParser.cpp
+++ b/zParserExtender/zParser.cpp
@@ -57,7 +57,7 @@ namespace GOTHIC_ENGINE {
   HOOK Hook_zCParser_SaveDat PATCH( &zCParser::SaveDat, &zCParser::SaveDat_Union );
 
   int zCParser::SaveDat_Union( zSTRING& name ) {
-    if( zParserExtender.GetParser()->enableParsing == NinjaParseID )
+    if( zParserExtender.GetParseID() == NinjaParseID )
       return THISCALL( Hook_zCParser_SaveDat )(name);
 
     // Apply all hooks
@@ -123,7 +123,7 @@ namespace GOTHIC_ENGINE {
   HOOK Hook_zCParser_ParseBlock PATCH( &zCParser::ParseBlock, &zCParser::ParseBlock_Union );
 
   void zCParser::ParseBlock_Union() {
-    if( zParserExtender.GetParser()->enableParsing == NinjaParseID )
+    if( zParserExtender.GetParseID() == NinjaParseID )
       return THISCALL( Hook_zCParser_ParseBlock )();
 
     if( !zParserExtender.ExtendedParsingEnabled() )

--- a/zParserExtender/zParserExtender.cpp
+++ b/zParserExtender/zParserExtender.cpp
@@ -618,7 +618,10 @@ namespace GOTHIC_ENGINE {
 
       // Compile parsed scripts...
       CurrentCompileInfo = DefaultCompileInfo;
-      activeParsers.Insert( parser );
+      if( !activeParsers.HasEqual( parser ) ) {
+        activeParsers.Insert( parser );
+      }
+
       for( uint i = 0; i < activeParsers.GetNum(); i++ ) {
         CurrentParser = activeParsers[i];
         CurrentParser->CreatePCode();

--- a/zParserExtender/zParserExtender.cpp
+++ b/zParserExtender/zParserExtender.cpp
@@ -599,7 +599,7 @@ namespace GOTHIC_ENGINE {
         CheckExtendedSymbolsEnd( par );
 
         if( parsed != 0 ) {
-          bool parsed = activeParsers & par;
+          parsed = activeParsers & par;
           if( !parsed )
             par->SetEnableParsing_Union( False );
 

--- a/zParserExtender/zParserExtender.cpp
+++ b/zParserExtender/zParserExtender.cpp
@@ -695,6 +695,11 @@ namespace GOTHIC_ENGINE {
   }
 
 
+  int zCParserExtender::GetParseID() {
+    return zCParser::enableParsing;
+  }
+
+
   bool zCParserExtender::MergeModeEnabled() {
     return CurrentCompileInfo.MergeMode && ParsingEnabled;
   }

--- a/zParserExtender/zParserExtender.cpp
+++ b/zParserExtender/zParserExtender.cpp
@@ -565,9 +565,6 @@ namespace GOTHIC_ENGINE {
 
         // Search game parser by name
         zCParser* par = GetParserByParserName( scriptInfo.ParserName );
-        zCParser::cur_parser = par;
-        CurrentParser = par;
-        CurrentParser->InitializeNamespace( GetDefaultNamespace() );
 
         if( par == Null ) {
           if( zCParserExtender::MessagesLevel >= 1 )
@@ -579,6 +576,10 @@ namespace GOTHIC_ENGINE {
                    colWarn3 << endl;
           continue;
         }
+
+        zCParser::cur_parser = par;
+        CurrentParser = par;
+        CurrentParser->InitializeNamespace( GetDefaultNamespace() );
 
         ParStackMaxLength = parser->stack.GetDynSize() - 4;
 

--- a/zParserExtender/zParserExtender.h
+++ b/zParserExtender/zParserExtender.h
@@ -80,6 +80,7 @@ namespace GOTHIC_ENGINE {
     zCParser* GetParser();
     zCParser* GetParserExternals();
     zCPar_Symbol* GetExternalFunction( const string& symName );
+    int GetParseID();
 
     bool MergeModeEnabled();
     bool CompileDatEnabled();

--- a/zParserExtender/zSymbolTable.cpp
+++ b/zParserExtender/zSymbolTable.cpp
@@ -11,7 +11,7 @@ namespace GOTHIC_ENGINE {
     zCPar_Symbol* NewSymbol;
     int_t OldIndex;
 
-    static zTCallReplaceInfo& Create( int_t replaceLength, zCParser* parser, zCPar_Symbol* oldSymbol, zCPar_Symbol* newSymbol, int_t oldIndex ) {
+    static zTCallReplaceInfo& Create( int_t replaceLength, zCParser* scriptParser, zCPar_Symbol* oldSymbol, zCPar_Symbol* newSymbol, int_t oldIndex ) {
       for( uint i = 0; i < CallReplaceInfos.GetNum(); i++ ) {
         if( CallReplaceInfos[i].NewSymbol == oldSymbol ) {
           CallReplaceInfos[i].NewSymbol = newSymbol;
@@ -21,8 +21,8 @@ namespace GOTHIC_ENGINE {
       }
 
       zTCallReplaceInfo& callReplace = CallReplaceInfos.Create();
-      callReplace.ReplaceLength      = zParserExtender.GetParser()->stack.GetDynSize() - 4;
-      callReplace.Parser             = zParserExtender.GetParser();
+      callReplace.ReplaceLength      = replaceLength;
+      callReplace.Parser             = scriptParser;
       callReplace.OldSymbol          = oldSymbol;
       callReplace.NewSymbol          = newSymbol;
       callReplace.OldIndex           = oldIndex;

--- a/zParserExtender/zSymbolTable.cpp
+++ b/zParserExtender/zSymbolTable.cpp
@@ -333,13 +333,13 @@ namespace GOTHIC_ENGINE {
   }
 
 
-  uint zCPar_SymbolTable::RenameSymbol( zCPar_Symbol* sym, const zSTRING& newName, zCPar_Symbol* newSym ) {
+  uint zCPar_SymbolTable::RenameSymbol( zCParser* scriptParser, zCPar_Symbol* sym, const zSTRING& newName, zCPar_Symbol* newSym ) {
     uint collisions = 1;
 
     int nextIndex = GetIndex( newName );
     if( nextIndex != Invalid ) {
       zCPar_Symbol* nextSym = table[nextIndex];
-      collisions += RenameSymbol( nextSym, nextSym->GetName() + "_OLD", sym );
+      collisions += RenameSymbol( scriptParser, nextSym, nextSym->GetName() + "_OLD", sym );
     }
 
     cur_table          = this;
@@ -348,7 +348,7 @@ namespace GOTHIC_ENGINE {
 
     while( list ) {
       int index = GetIndex( list );
-      zParserExtender.GetParser()->RenameTreeNode( list, newName );
+      scriptParser->RenameTreeNode( list, newName );
       tablesort.RemoveOrder( index );
       if( !zCParser::OverrideNextSymbol ) {
         list->name.Replace( oldName, newName );

--- a/zParserExtender/zSymbolTable.cpp
+++ b/zParserExtender/zSymbolTable.cpp
@@ -379,8 +379,14 @@ namespace GOTHIC_ENGINE {
     if( !sym )
       return False;
 
+    zCParser* extParser = zParserExtender.GetParser();
+
+    if ( !extParser  || &extParser->symtab != this ) {
+        return (this->*Hook_zCPar_SymbolTable_Insert)(sym);
+    }
+
     // Search new PFX symbols for creation new emitters
-    if( zParserExtender.ExtendedParsingEnabled() && zParserExtender.GetParser() == Gothic::Parsers::PFX )
+    if( zParserExtender.ExtendedParsingEnabled() && extParser == Gothic::Parsers::PFX )
       zParserExtender.InsertPFXSymbol( sym );
 
     int index = GetIndex( sym->name );
@@ -392,7 +398,7 @@ namespace GOTHIC_ENGINE {
       bool internalToExternal = !sym->HasFlag( zPAR_FLAG_EXTERNAL ) && oldSym->HasFlag( zPAR_FLAG_EXTERNAL );
 
       if( internalToExternal || zParserExtender.MergeModeEnabled() ) {
-        RenameSymbol( oldSym, oldSym->GetName() + "_OLD", sym );
+        RenameSymbol( extParser, oldSym, oldSym->GetName() + "_OLD", sym );
 
         if( zCParserExtender::MessagesLevel >= 3 )
           cmd << colParse2 << "zParserExtender: " <<
@@ -411,12 +417,12 @@ namespace GOTHIC_ENGINE {
             string oldTypeName = SymbolTypeToString( oldSym->type );
             string newTypeName = SymbolTypeToString( sym->type );
             string errorText   = string::Combine( "The replacement symbol '%z' has incorrect type! Src '%z' != new '%z'", sym->name, oldTypeName, newTypeName );
-            zParserExtender.GetParser()->Error( Z errorText, 0 );
+            extParser->Error( Z errorText, 0 );
           }
 
           zTCallReplaceInfo::Create(
-            zParserExtender.GetParser()->stack.GetDynSize() - 4,
-            zParserExtender.GetParser(),
+            extParser->stack.GetDynSize() - 4,
+            extParser,
             oldSym,
             sym,
             index

--- a/zParserExtender/zSymbolTable.cpp
+++ b/zParserExtender/zSymbolTable.cpp
@@ -283,7 +283,7 @@ namespace GOTHIC_ENGINE {
   static bool s_DeclareEvent = false;
 
   int zCPar_SymbolTable::Insert_Union( zCPar_Symbol* sym ) {
-    if( s_DeclareEvent ) {
+    if( s_DeclareEvent && zCParser::cur_parser ) {
       s_DeclareEvent = false;
       // RegisterEvent( sym->name );
 
@@ -292,9 +292,8 @@ namespace GOTHIC_ENGINE {
       sym->name         = Z string::Combine( "EVENT.%z.%z", sym->name, fileName );
       int ok            = InsertAt_Union( sym, True, true );
       int symIndex      = table.Search( sym );
-      zCParser* parser  = zCParser::GetParser();
 
-      zTEventFuncCollection::GetCollection( parser ).PushIndex( keyName, symIndex );
+      zTEventFuncCollection::GetCollection( zCParser::cur_parser ).PushIndex( keyName, symIndex );
       return ok;
     }
 

--- a/zParserExtender/zSymbolTable.cpp
+++ b/zParserExtender/zSymbolTable.cpp
@@ -41,10 +41,10 @@ namespace GOTHIC_ENGINE {
   }
 
   // Find and replace call address to other function
-  void ReplaceStackCallAddress( TReferralTokenList& referalTokens, zCPar_Stack& stack, zCPar_Symbol* symLeft, zCPar_Symbol* symRight, int_t oldIndex, int_t length ) {
+  void ReplaceStackCallAddress( TReferralTokenList& referalTokens, zCParser& scriptParser, zCPar_Symbol* symLeft, zCPar_Symbol* symRight, int_t oldIndex, int_t length ) {
     int oldPos       = symLeft->single_intdata;
     int newPos       = symRight->single_intdata;
-    int newIndex     = zParserExtender.GetParser()->symtab.GetIndex_Safe( symRight );
+    int newIndex     = scriptParser.symtab.GetIndex_Safe( symRight );
     int calls        = 0;
     int refs         = 0;
     int symType      = symLeft->type;
@@ -92,17 +92,21 @@ namespace GOTHIC_ENGINE {
   
 
   void PostCompileCallReplace() {
+    zCParser* extParser = zParserExtender.GetParser();
+    if ( !extParser ) {
+      return;
+    }
     TReferralTokenList referalTokens;
-    referalTokens.Init( zParserExtender.GetParser()->stack );
+    referalTokens.Init( extParser->stack );
 
     for( uint i = 0; i < zTCallReplaceInfo::CallReplaceInfos.GetNum(); i++ ) {
       zTCallReplaceInfo& info = zTCallReplaceInfo::CallReplaceInfos[i];
-      if( info.Parser != zParserExtender.GetParser() )
+      if( info.Parser != extParser )
         continue;
 
       ReplaceStackCallAddress(
         referalTokens,
-        info.Parser->stack,
+        *info.Parser,
         info.OldSymbol,
         info.NewSymbol,
         info.OldIndex,


### PR DESCRIPTION
This PR improves zParserExtender by addressing safety issues and fixing a critical crash:
- Fix Crash on Function Declarations: Addressed a crash that occurred when a function with same name was declared in both scripts and an external plugin.
- Validation: Added checks to ensure parser pointers validity and null safety.
- Arguments: Replaced usage of global state in functions with explicit zCParser* arguments.
- Refactoring: Moved ParseID getter to zCParserExtender.
- Safety Improvements: Prevented duplicate active parsers and ensured CurrentParser is never null.