### PR TITLE
Compatibility with 3rd party compilers like dacode

### DIFF
--- a/zParserExtender/Menu.cpp
+++ b/zParserExtender/Menu.cpp
@@ -59,8 +59,8 @@ namespace GOTHIC_ENGINE {
     zCParser* par = Null;
     if( !createFuncList ) {
       par = zCParser::GetParser();
-      if( par->GetIndex( funcName ) != Invalid )
-        return true;
+      // if( par->GetIndex( funcName ) != Invalid )
+      //   return true;
 
       if( funcName.IsEmpty() )
         return false;

--- a/zParserExtender/ZenGin/Gothic_UserAPI/zCParser.inl
+++ b/zParserExtender/ZenGin/Gothic_UserAPI/zCParser.inl
@@ -94,3 +94,5 @@ int FindIndex_Union( zSTRING& );
 
 void __cdecl DefineExternal_Union( zSTRING const&, int( __cdecl* )(), int, int, ... );
 static bool OverrideNextSymbol;
+
+int IsExternalFunctionDefined(zCPar_Symbol* funcSym);

--- a/zParserExtender/zExternals.cpp
+++ b/zParserExtender/zExternals.cpp
@@ -1740,8 +1740,8 @@ namespace GOTHIC_ENGINE {
     zCParser* par = Null;
     if( !createFuncList ) {
       par = zCParser::GetParser();
-      if( par->GetIndex( funcName ) != Invalid )
-        return true;
+      // if( par->GetIndex( funcName ) != Invalid )
+      //   return true;
 
       if( funcName.IsEmpty() )
         return false;

--- a/zParserExtender/zExternals_Vobs.cpp
+++ b/zParserExtender/zExternals_Vobs.cpp
@@ -465,8 +465,8 @@ namespace GOTHIC_ENGINE {
     zCParser* par = Null;
     if( !createFuncList ) {
       par = zCParser::GetParser();
-      if( par->GetIndex( funcName ) != Invalid )
-        return true;
+      // if( par->GetIndex( funcName ) != Invalid )
+      //   return true;
 
       if( funcName.IsEmpty() )
         return false;

--- a/zParserExtender/zParser.cpp
+++ b/zParserExtender/zParser.cpp
@@ -698,7 +698,18 @@ namespace GOTHIC_ENGINE {
     
     return classObject;
   }
-
+  
+  int zCParser::IsExternalFunctionDefined(zCPar_Symbol* funcSym)
+  {
+    // Check if function is external
+    if (!funcSym || funcSym->type != zPAR_TYPE_FUNC || !funcSym->HasFlag(zPAR_FLAG_EXTERNAL))
+      return -1;
+    
+    // if function is external and has 0 stack position, then it is not defined
+    int stackPos;
+    funcSym->GetStackPos(stackPos, 0);
+    return stackPos > 0;
+  }
 
   extern bool ActivateDynamicExternal( const string& funcName );
 
@@ -707,7 +718,7 @@ namespace GOTHIC_ENGINE {
       return false;
 
     zCPar_Symbol* sym = GetSymbol( symName );
-    if( sym && !forceReplace )
+    if( sym && (!forceReplace || IsExternalFunctionDefined(sym)))
       return false;
 
     return ActivateDynamicExternal( symName );


### PR DESCRIPTION
When running the game with scripts already compiled zPE doesn't define its externals. That happens bacause it expects them not to exist in sybmbol table (returns if `par->GetIndex( funcName ) != Invalid`). Instead of this I added check that ensures symbols stack position is 0 (it was not defined by other plugin) and defines the function if so.